### PR TITLE
Fixed a styling issue with the Code Wrapper divs

### DIFF
--- a/src/components/Modals/ExportFileModal.module.scss
+++ b/src/components/Modals/ExportFileModal.module.scss
@@ -252,8 +252,3 @@ pre {
   color: white;
   // border-radius: 6px;
 }
-
-// #codeWrapper {
-//   width: 50%;
-//   color: #fff;
-// }

--- a/src/components/Modals/ExportFileModal.module.scss
+++ b/src/components/Modals/ExportFileModal.module.scss
@@ -224,9 +224,11 @@
   flex: 1;
   flex-direction: column;
 }
+
 #endPointGuide {
   margin: 8px;
 }
+
 #configGuide {
   display: flex;
   flex: 1;
@@ -235,6 +237,7 @@
 }
 
 pre {
+  white-space: pre-wrap;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -242,10 +245,15 @@ pre {
   margin-top: -4px;
   margin-bottom: 8px;
   overflow: auto;
-  width: 97.5%;
+  // width: 97.5%;
   font-size: 85%;
   line-height: 1.45;
   background-color: #0a1f40;
   color: white;
   // border-radius: 6px;
 }
+
+// #codeWrapper {
+//   width: 50%;
+//   color: #fff;
+// }

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -257,9 +257,9 @@ const Modal = ({
                   2. Install dependencies and Jest.
                 </AccordionSummary>
                 <AccordionDetails id={styles.accordionDetails}>
-                  <div>
+                  <div id={styles.accordionDiv}>
                     <pre>
-                      <div className="code-wrapper">
+                      <div className="code-wrapper" id={styles.codeWrapper}>
                         <code>
                           {script.install}
                         </code>


### PR DESCRIPTION
Justin found a pre-wrap CSS rule that we implemented to fix an issue where code snippets were extending beyond their code wrapper.

Also added code wrapper styling to a div in Accessibility testing that was missing.