### PR TITLE
Removed btnFeedback when install dependencies is clicked inside modal

### DIFF
--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -309,7 +309,6 @@ const Modal = ({
                     <span id={styles.newTestButtons}>
                       <button id={styles.save} onClick={installDependencies}>Install</button>
                       <div id={styles.feedback}>
-                        {btnFeedback.installed === false ? null : <p>Dependencies installation have been complete</p>}
                       </div>
                     </span>
                   </div>


### PR DESCRIPTION

Co-authored-by: Justin Baik <bij3377@gmail.com>
Co-authored-by: Max Weisenberger <germanbluemax@gmail.com>
Co-authored-by: Mo Hmaidi <mhmaidi789@gmail.com>
Co-authored-by: Dieu Huynh <dieuhhuynh@gmail.com>